### PR TITLE
[FEAT] 알림연결 heartBeat 주기적 발송, 싱글톤 객체로 처리

### DIFF
--- a/src/main/java/com/dailyon/notificationservice/domain/notification/document/enums/NotificationType.java
+++ b/src/main/java/com/dailyon/notificationservice/domain/notification/document/enums/NotificationType.java
@@ -10,7 +10,8 @@ public enum NotificationType {
     ORDER_ARRIVED("배송 도착", "주문하신 상품이 도착했습니다."),
     AUCTION_END("실시간 경매 종료", "실시간 경매가 종료되었습니다."),
     GIFT_RECEIVED("선물", "선물을 받았습니다."),
-    POINTS_EARNED_SNS("SNS 구매유도 포인트 적립", "SNS를 통해 포인트가 적립되었습니다.");
+    POINTS_EARNED_SNS("SNS 구매유도 포인트 적립", "SNS를 통해 포인트가 적립되었습니다."),
+    HEARTBEAT("하트비트", "연결 유지용 주기적 송신.");
     // 정의하면서 넣을 예정
 
     private final String name;

--- a/src/main/java/com/dailyon/notificationservice/domain/notification/dto/HeartbeatServerSentEvent.java
+++ b/src/main/java/com/dailyon/notificationservice/domain/notification/dto/HeartbeatServerSentEvent.java
@@ -1,0 +1,23 @@
+package com.dailyon.notificationservice.domain.notification.dto;
+
+import com.dailyon.notificationservice.domain.notification.document.enums.NotificationType;
+import org.springframework.http.codec.ServerSentEvent;
+
+public class HeartbeatServerSentEvent {
+
+    private static final NotificationData HEARTBEAT_INSTANCE = NotificationData.builder()
+            .id(null)
+            .message(null)
+            .linkUrl(null)
+            .notificationType(NotificationType.HEARTBEAT)
+            .read(false)
+            .build();
+
+    private static final ServerSentEvent<NotificationData> HEARTBEAT_EVENT = ServerSentEvent.<NotificationData>builder()
+            .data(HEARTBEAT_INSTANCE)
+            .build();
+
+    public static ServerSentEvent<NotificationData> getInstance() {
+        return HEARTBEAT_EVENT;
+    }
+}


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
1. 알림 연결 주기적 heartBeat 발송 (15초)
2. heartBeat 객체 싱글톤으로 처리
3. NotificationType에 HEARBEAT 추가
<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요? ✅

| ✅ | content|
|:--:|:--|
|   |새로운 기능 추가|
|   |버그 수정|
|   |CSS 등 사용자 UI 디자인 변경|
|   |코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)|
|   |코드 리팩토링|
|   |주석 추가 및 수정|
|   |문서 수정|
|   |테스트 추가, 테스트 리팩토링|
|   |빌드 부분 혹은 패키지 매니저 수정|
|   |파일 혹은 폴더명 수정|
|   |파일 혹은 폴더 삭제|

## 스크린 샷


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] local에서 실행되는 것을 확인 했나요?
- [ ] 변경 사항에 대해 테스트를 통과했나요?
- [ ] 설계와 관련된 변경 사항을 공유했나요? (api 스펙, entity 등)